### PR TITLE
Fixes #8683 - allow Celery to bind 5000/tcp

### DIFF
--- a/katello.te
+++ b/katello.te
@@ -26,6 +26,7 @@ policy_module(katello, @@VERSION@@)
 require{
     type passenger_t;
     type websockify_t;
+    type httpd_t;
 }
 
 ######################################
@@ -71,3 +72,14 @@ corenet_tcp_connect_amqp_port(passenger_t)
 # Katello uses certs in /etc/pki/katello for websockets
 miscfiles_read_certs(websockify_t)
 
+######################################
+#
+# Pulp
+#
+
+# Katello installer configures Celery to listen on port 5000
+ifdef(`distro_rhel6', `
+    corenet_tcp_bind_commplex_port(httpd_t)
+',`
+    corenet_tcp_bind_commplex_main_port(httpd_t)
+')


### PR DESCRIPTION
This replaces https://github.com/theforeman/foreman-selinux/pull/41

This module will not load until rules are removed from Foreman core selinux
policy. Until then, please test manually (create a policy and add those rules
in, compile, test).

If you need assistance how to do that, ping me.