### PR TITLE
Fixes #9106 - passenger allowed to connect to AMQP/tcp

### DIFF
--- a/katello.te
+++ b/katello.te
@@ -72,6 +72,9 @@ corenet_tcp_connect_amqp_port(passenger_t)
 # Katello uses certs in /etc/pki/katello for websockets
 miscfiles_read_certs(websockify_t)
 
+# Katello connects to AMQP service
+corenet_tcp_connect_amqp_port(passenger_t)
+
 ######################################
 #
 # Pulp


### PR DESCRIPTION
This replaces: https://github.com/theforeman/foreman-selinux/pull/43

@inecas please review. When testing please compile a policy only with this
block, katello-selinux will not yet work (changes needs to be done in the core
policy).