### PR TITLE
Remove elasticsearch policy and port

### DIFF
--- a/katello-selinux-disable
+++ b/katello-selinux-disable
@@ -4,11 +4,6 @@ set +e
 for selinuxvariant in targeted
 do
   if /usr/sbin/semodule -s $selinuxvariant -l >/dev/null; then
-    # Remove all user defined ports (including the default one)
-    /usr/sbin/semanage port -E | \
-      grep elasticsearch_port_t | \
-      sed s/-a/-d/g | \
-      /usr/sbin/semanage -S $selinuxvariant -i -
     # Unload policy
     /usr/sbin/semodule -s $selinuxvariant -r katello
   fi

--- a/katello-selinux-enable
+++ b/katello-selinux-enable
@@ -11,8 +11,12 @@ do
     /usr/sbin/semanage module -S $selinuxvariant \
       -a /usr/share/selinux/${selinuxvariant}/katello.pp.bz2
 
-    /usr/sbin/semanage port -E | grep -q elasticsearch_port_t || \
-      echo "port -a -t elasticsearch_port_t -p tcp 9200-9300" > $TMP
+    # Remove previously defined elasticsearch_port_t
+    # (this can be removed in future release)
+    /usr/sbin/semanage port -E | \
+      grep elasticsearch_port_t | \
+      sed s/-a/-d/g | \
+      /usr/sbin/semanage -S $selinuxvariant -i -
 
     /usr/sbin/semanage -S $selinuxvariant -i $TMP
   fi

--- a/katello.te
+++ b/katello.te
@@ -43,21 +43,6 @@ require{
 
 ######################################
 #
-# Elasticsearch
-#
-
-# We carry elasticsearch policy until it is delivered to RHEL6:
-# https://bugzilla.redhat.com/show_bug.cgi?id=1102119
-optional_policy(`
-    gen_require(`
-        type elasticsearch_port_t;
-    ')
-
-    corenet_port(elasticsearch_port_t)
-')
-
-######################################
-#
 # Katello plugin
 #
 
@@ -68,14 +53,6 @@ init_exec_script_files(passenger_t)
 
 ifndef(`distro_rhel7', `
     consoletype_exec(passenger_t)
-')
-
-# Katello does connect to Elasticsearch services
-optional_policy(`
-    gen_require(`
-        type elasticsearch_port_t;
-    ')
-    allow passenger_t elasticsearch_port_t:tcp_socket name_connect;
 ')
 
 # katello does connect to AMQP service


### PR DESCRIPTION
This patch is needed to be able to actually upgrade via yum, otherwise
elasticsearch_port_t causes issues during yum transaction.

This must be merged ideally in the same time as
https://github.com/theforeman/foreman-selinux/pull/44 otherwise nightly will
not be upgradeable.

EDIT: This patch now removes the policy completely.