### PR TITLE
Refs #9216 - added 8080 to allowed http cache ports

### DIFF
--- a/katello.te
+++ b/katello.te
@@ -91,6 +91,7 @@ corenet_tcp_connect_amqp_port(passenger_t)
 optional_policy(`
     tunable_policy(`passenger_can_connect_http_proxy', `
         corenet_tcp_connect_squid_port(passenger_t)
+        corenet_tcp_connect_http_cache_port(passenger_t)
     ')
 ')
 


### PR DESCRIPTION
I have recently added squid port 3128, but this one is often used too for
http(s) cache. This improves it.