### PR TITLE
Fixes #13781 - update to allow reading of /var/lib/pulp

### DIFF
--- a/katello.te
+++ b/katello.te
@@ -72,6 +72,12 @@ optional_policy(`
     ')
 ')
 
+# Katello can be configured to read from pulp's published dir
+optional_policy(`
+    apache_read_sys_content_rw_files(passenger_t)
+    apache_read_sys_content_rw_dirs(passenger_t)
+')
+
 
 ######################################
 #


### PR DESCRIPTION
Katello needs to read from /var/lib/pulp to perform exports