### PR TITLE
Fixes #14362 - allow passenger to write to /var/www/html/*

### DIFF
--- a/katello.te
+++ b/katello.te
@@ -74,6 +74,7 @@ optional_policy(`
 
 # Katello can be configured to read from pulp's published dir
 optional_policy(`
+    apache_manage_sys_content(passenger_t)
     apache_manage_sys_content_rw(passenger_t)
 ')
 


### PR DESCRIPTION
Previously, katello could not write to /var/www/html/*. However, during testing
we found that exporting directly to /var/www/html/pub/export is a popular use
case.

This rule allows passenger to write to /var/www/html/*. I successfully compiled
it on el7 and I visually confirmed that the rule exists on el6 as well.