### PR TITLE
update policy for scl mongo db dir

### DIFF
--- a/katello-selinux-relabel
+++ b/katello-selinux-relabel
@@ -15,8 +15,9 @@
   /etc/cron.d/foreman* \
   /usr/lib/ruby/gems/1.8/gems/passenger-* \
   /usr/lib64/gems/ruby/passenger-*/agents \
-  /usr/lib64/ruby/site_ruby/1.8/x86_64-linux/agents
-
+  /usr/lib64/ruby/site_ruby/1.8/x86_64-linux/agents \
+  /var/lib/mongodb
+  
 # relabel SCL mod_passenger and foreman plugins if SCL is found
 [ -d /opt/rh/ruby193/ ] && /sbin/restorecon -ri $* \
   /opt/rh/ruby193/root/usr/share/gems/gems/passenger-* \

--- a/katello.fc
+++ b/katello.fc
@@ -15,3 +15,6 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see http://www.gnu.org/licenses/.
 #
+
+# Mongo db dir
+/var/lib/mongodb/ gen_context(system_u:object_r:mongod_var_lib_t,s0)


### PR DESCRIPTION
We are switching to SCL Mongo 3.4 and it uses a different set of directories /opt, we are changing the paths with Puppet but since we are telling Mongo from SCL to use a different DB directory than what it is normally used we need to update the SELinux file context or else the installer fails. 