### PR TITLE
Fixes #26520 - allow execmem

### DIFF
--- a/katello.te
+++ b/katello.te
@@ -46,6 +46,9 @@ require{
 # Katello plugin
 #
 
+# Allow FFI library callbacks - see RM#26520 for more info
+allow passenger_t self:process execmem;
+
 # katello does connect to AMQP service
 corenet_tcp_connect_amqp_port(passenger_t)
 


### PR DESCRIPTION
FFI library callback feature executes mapped memory of temporary files. This
sounds dangerous, however FFI authors do not think this is a problem, they did
not find a workaround in the FFI code as a good option and they recommend to
allow this in SELinux in the official documentation:

* https://bitbucket.org/cffi/cffi/issues/231
* https://cffi.readthedocs.io/en/latest/using.html#callbacks

This patch enables execmem both for passenger and smart proxy process as there
is no other good solution to this problem.