### PR TITLE
Add Crane policy again

### DIFF
--- a/katello.te
+++ b/katello.te
@@ -74,3 +74,13 @@ require {
   type load_policy_t;
 }
 userdom_write_inherited_user_tmp_files(load_policy_t)
+
+
+######################################
+#
+# Pulp
+#
+
+# Katello installer configures crane to listen on port 5000 with alternate 5001
+corenet_tcp_bind_commplex_main_port(httpd_t)
+corenet_tcp_bind_commplex_link_port(httpd_t)


### PR DESCRIPTION
3fa42180af1275fe24ffe699f111be5d4d22263f removed the crane port, but it's still needed.

Note I added the link port as well, but AFAIK the installer doesn't use 5001 at all.