### PR TITLE
Fixes #27073 - workarounds for RHEL 8.0

### DIFF
--- a/katello.te
+++ b/katello.te
@@ -41,6 +41,17 @@ require{
     type httpd_t;
 }
 
+# https://bugzilla.redhat.com/show_bug.cgi?id=1716971
+# Can be removed in RHEL 8.4 timeframe
+optional_policy(`
+    rpm_manage_cache(rhsmcertd_t)
+')
+
+# https://bugzilla.redhat.com/show_bug.cgi?id=1716973
+# Can be removed in RHEL 8.4 timeframe
+files_mmap_usr_files(qpidd_t)
+fs_getattr_all_fs(qpidd_t)
+
 ######################################
 #
 # Katello plugin


### PR DESCRIPTION
The two Katello blocker issues were resolved and will be part of RHEL 8.1. Until then, we need workarounds:

1716971 - RHSM daemon denials when configuring Satellite 6 repositories
https://bugzilla.redhat.com/show_bug.cgi?id=1716971

1716973 - Denials for qpidd when configured for Satellite 6.6 on RHEL8
https://bugzilla.redhat.com/show_bug.cgi?id=1716973

I will leave a comment in the policy file to remove them after 8.4+ (some time until people update their systems.).