### PR TITLE
Fixes #29603 - Allow Passenger to connect to Artemis

### DIFF
--- a/katello.te
+++ b/katello.te
@@ -39,6 +39,8 @@ require{
     type passenger_t;
     type websockify_t;
     type httpd_t;
+    type candlepin_activemq_port_t;
+    class tcp_socket name_connect;
 }
 
 ######################################
@@ -49,8 +51,8 @@ require{
 # Allow FFI library callbacks - see RM#26520 for more info
 allow passenger_t self:process execmem;
 
-# katello does connect to AMQP service
-corenet_tcp_connect_amqp_port(passenger_t)
+# Candlepin Event Listener connects to Artemis
+allow passenger_t candlepin_activemq_port_t:tcp_socket name_connect;
 
 # Katello uses certs in /etc/pki/katello for websockets
 miscfiles_read_certs(websockify_t)


### PR DESCRIPTION
I tested this on a nightly box given to me by loading the policy remotely (make remote-load) and hammer ping works:

```
candlepin_events: 
    Status:          ok
    message:         0 Processed, 0 Failed
    Server Response: Duration: 0ms
```

**To test:**
- Spin up a nightly box w/ staging repos and `--foreman-passenger true` installer option
- Notice `hammer ping` fails for candlepin_events
- Apply this selinux policy remotely to your host `make remote-load HOST=my.host.lan DISTRO=rhel7`
- Restart httpd
- `hammer ping` should be OK for candlepin_events