### PR TITLE
Fixes #30088 - rules for puma app server

### DIFF
--- a/katello-selinux-relabel
+++ b/katello-selinux-relabel
@@ -1,26 +1,5 @@
 #!/bin/bash
 
-# relabel foreman
-/sbin/restorecon -ri $* /usr/share/foreman \
-  /usr/share/katello \
-  /var/lib/foreman \
-  /var/run/foreman \
-  /run/foreman \
-  /var/log/foreman \
-  /etc/foreman \
-  /etc/puppet/node.rb \
-  /etc/sysconfig/foreman* \
-  /etc/rc.d/init.d/foreman* \
-  /etc/logrotate.d/foreman* \
-  /etc/cron.d/foreman* \
-  /usr/lib/ruby/gems/1.8/gems/passenger-* \
-  /usr/lib64/gems/ruby/passenger-*/agents \
-  /usr/lib64/ruby/site_ruby/1.8/x86_64-linux/agents
-
-# relabel SCL mod_passenger and foreman plugins if SCL is found
-[ -d /opt/rh/ruby193/ ] && /sbin/restorecon -ri $* \
-  /opt/rh/ruby193/root/usr/share/gems/gems/passenger-* \
-  /opt/rh/ruby193/root/usr/lib64/gems/exts/passenger-*/agents \
-  /opt/rh/ruby193/root/usr/share/gems/gems/foreman*
+# katello policy does not carry any file context
 
 exit 0

--- a/katello.te
+++ b/katello.te
@@ -28,7 +28,7 @@ policy_module(katello, @@VERSION@@)
 ## Determine whether passenger can connect to HTTP(s) proxy (Squid)
 ## </p>
 ## </desc>
-gen_tunable(passenger_can_connect_http_proxy, true)
+gen_tunable(foreman_rails_can_connect_http_proxy, true)
 
 #######################################
 #
@@ -36,6 +36,7 @@ gen_tunable(passenger_can_connect_http_proxy, true)
 #
 
 require{
+    type foreman_rails_t;
     type passenger_t;
     type websockify_t;
     type httpd_t;
@@ -48,27 +49,24 @@ require{
 # Katello plugin
 #
 
-# Allow FFI library callbacks - see RM#26520 for more info
-allow passenger_t self:process execmem;
-
 # Candlepin Event Listener connects to Artemis
-allow passenger_t candlepin_activemq_port_t:tcp_socket name_connect;
+allow foreman_rails_t candlepin_activemq_port_t:tcp_socket name_connect;
 
 # Katello uses certs in /etc/pki/katello for websockets
 miscfiles_read_certs(websockify_t)
 
 # Katello can be configured to connect to Squid
 optional_policy(`
-    tunable_policy(`passenger_can_connect_http_proxy', `
-        corenet_tcp_connect_squid_port(passenger_t)
-        corenet_tcp_connect_http_cache_port(passenger_t)
+    tunable_policy(`foreman_rails_can_connect_http_proxy', `
+        corenet_tcp_connect_squid_port(foreman_rails_t)
+        corenet_tcp_connect_http_cache_port(foreman_rails_t)
     ')
 ')
 
 # Katello can be configured to read from pulp's published dir
 optional_policy(`
-    apache_manage_sys_content(passenger_t)
-    apache_manage_sys_content_rw(passenger_t)
+    apache_manage_sys_content(foreman_rails_t)
+    apache_manage_sys_content_rw(foreman_rails_t)
 ')
 
 # Installation generates load denial
@@ -77,6 +75,22 @@ require {
 }
 userdom_write_inherited_user_tmp_files(load_policy_t)
 
+######################################
+#
+# Katello plugin - passenger rules
+# (to be removed in 2.2 or later)
+#
+
+# <REMOVE>
+allow passenger_t self:process execmem;
+allow passenger_t candlepin_activemq_port_t:tcp_socket name_connect;
+corenet_tcp_connect_squid_port(passenger_t)
+corenet_tcp_connect_http_cache_port(passenger_t)
+optional_policy(`
+    apache_manage_sys_content(passenger_t)
+    apache_manage_sys_content_rw(passenger_t)
+')
+# </REMOVE>
 
 ######################################
 #


### PR DESCRIPTION
Change that was made in Foreman core too: domain is now `foreman_rails_t` so all rules need to be rewritten. I dropped one rule which is already present in core. All the old passenger rules are kept temporarily because passenger is still an option (fallback), but in the future this can be removed.

The patch also drops unnecessary relabel - all the file context is set via `foreman-selinux-relabel` this this was only making RPM installation/upgrade slower as it was not necessary to relabel everything the 2nd time. Katello installs after Foreman policy (RPM dependency).