### PR TITLE
Fixes #30123 - Allow Puma to connect to Artemis

### DIFF
--- a/katello.te
+++ b/katello.te
@@ -40,6 +40,7 @@ require{
     type websockify_t;
     type httpd_t;
     type candlepin_activemq_port_t;
+    type foreman_rails_t;
     class tcp_socket name_connect;
 }
 
@@ -53,6 +54,7 @@ allow passenger_t self:process execmem;
 
 # Candlepin Event Listener connects to Artemis
 allow passenger_t candlepin_activemq_port_t:tcp_socket name_connect;
+allow foreman_rails_t candlepin_activemq_port_t:tcp_socket name_connect;
 
 # Katello uses certs in /etc/pki/katello for websockets
 miscfiles_read_certs(websockify_t)


### PR DESCRIPTION
Puma's context recently changed from unconfined_t to foreman_rails_t which broke the connection to Artemis

```
system_u:system_r:foreman_rails_t:s0 13633 ?   Ssl    0:32 puma 4.3.5 (tcp://127.0.0.1:3000) [foreman]
system_u:system_r:foreman_rails_t:s0 13836 ?   Sl     1:07 puma: cluster worker 0: 13633 [foreman]
system_u:system_r:foreman_rails_t:s0 13838 ?   Sl     4:23 puma: cluster worker 1: 13633 [foreman]
```

This PR fixed it. Generated from audit2allow

**to test**

spin up a nightly box with staging repos:

```
centos7-katello-nightly-staging:
  box: centos7-katello-nightly
  ansible:
    variables:
      katello_repositories_environment: staging
      foreman_repositories_environment: staging

```

use `hammer ping` to verify that candlepin_events is in the failed state.

Apply this policy remotely to the nightly box per README.md in this repo

```
    make remote-load HOST=my.host.lan DISTRO=rhel7                                                                                                                                            
```

in 10-15 seconds, check `hammer ping` again on the nightly box, and verify that candlepin_events is OK

