### PR TITLE
Refs #30087 - allow candlepin to bind port 23443

### DIFF
--- a/katello.te
+++ b/katello.te
@@ -55,6 +55,9 @@ corenet_port(katello_candlepin_port_t)
 # Connections to Candlepin
 allow foreman_rails_t katello_candlepin_port_t:tcp_socket name_connect;
 
+# Allow to bind to Candlepin
+allow tomcat_t katello_candlepin_port_t:tcp_socket name_bind;
+
 # Candlepin Event Listener connects to Artemis
 allow foreman_rails_t candlepin_activemq_port_t:tcp_socket name_connect;
 


### PR DESCRIPTION
PLEASE TEST. On my snap, I don't see the port configured:

```
grep -R 23443 /etc
```

Tomcat listens on the standard ports for me. Not sure why, I've been upgrading from snap 1 so maybe this was pushed later on.