### PR TITLE
Fixes #30378 - added uploader.sh typealias

### DIFF
--- a/katello.fc
+++ b/katello.fc
@@ -15,3 +15,6 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see http://www.gnu.org/licenses/.
 #
+
+# Red Hat Cloud plugin
+/var/lib/foreman/red_hat_inventory/uploads/uploader.sh -- gen_context(system_u:object_r:foreman_uploader_bin_t,s0)

--- a/katello.te
+++ b/katello.te
@@ -35,7 +35,8 @@ gen_tunable(foreman_rails_can_connect_http_proxy, true)
 # Declarations
 #
 
-require{
+require {
+    type bin_t;
     type foreman_rails_t;
     type passenger_t;
     type websockify_t;
@@ -97,6 +98,13 @@ optional_policy(`
     apache_manage_sys_content_rw(passenger_t)
 ')
 # </REMOVE>
+
+######################################
+#
+# Foreman Red Hat Cloud plugin
+#
+
+typealias bin_t alias foreman_uploader_bin_t;
 
 ######################################
 #


### PR DESCRIPTION
This is a solution to the current design, it would be probably better to create a generic upload script and put it into `/usr/libexec/foreman` or similar directory. After that, no rule should be needed.