### PR TITLE
Refs #30087 - allow candlepin to bind port 23443

### DIFF
--- a/katello.te
+++ b/katello.te
@@ -34,6 +34,7 @@ require{
     type websockify_t;
     type httpd_t;
     type candlepin_activemq_port_t;
+    type tomcat_t;
     class tcp_socket name_connect;
 }
 
@@ -47,6 +48,9 @@ corenet_port(katello_candlepin_port_t)
 
 # Connections to Candlepin
 allow foreman_rails_t katello_candlepin_port_t:tcp_socket name_connect;
+
+# Allow to bind to Candlepin
+allow tomcat_t katello_candlepin_port_t:tcp_socket name_bind;
 
 # Candlepin Event Listener connects to Artemis
 allow foreman_rails_t candlepin_activemq_port_t:tcp_socket name_connect;


### PR DESCRIPTION
This includes https://github.com/Katello/katello-selinux/pull/26 with the added require on `tomcat_t`.