### PR TITLE
Fixes #31499 - Allow tomcat name_connect to katello_candlepin_port_t

### DIFF
--- a/katello.te
+++ b/katello.te
@@ -50,6 +50,7 @@ allow foreman_rails_t katello_candlepin_port_t:tcp_socket name_connect;
 
 # Allow to bind to Candlepin
 allow tomcat_t katello_candlepin_port_t:tcp_socket name_bind;
+allow tomcat_t katello_candlepin_port_t:tcp_socket name_connect;
 
 # Candlepin Event Listener connects to Artemis
 allow foreman_rails_t candlepin_activemq_port_t:tcp_socket name_connect;


### PR DESCRIPTION
On hosts where the hostname has been changed (katello-change-hostname) there is a denial getting logged:

```
type=AVC msg=audit(1607442618.886:284): avc:  denied  { name_connect } for  pid=1173 comm="Thread-11" dest=23443 scontext=system_u:system_r:tomcat_t:s0 tcontext=system_u:object_r:katello_candlepin_port_t:s0 tclass=tcp_socket permissive=0

```

This fixes it!