### PR TITLE
use `if test … fi` instead of `test && …`

### DIFF
--- a/katello-selinux-enable
+++ b/katello-selinux-enable
@@ -25,6 +25,8 @@ do
     cat $TMP >> $LOG
 
     # Commit the changes
-    test -s $TMP && /usr/sbin/semanage -S $selinuxvariant -i $TMP | tee -a $LOG
+    if test -s $TMP; then
+      /usr/sbin/semanage -S $selinuxvariant -i $TMP | tee -a $LOG
+    end
   fi
 done


### PR DESCRIPTION
`test && …` exits non-zero if `test` exited non-zero, thus logging confising errors in RPM %post when the port is already present and thus no action is perfomed by `k-s-enable`:

    Running scriptlet: katello-selinux-5.0.0-1.el8.noarch
    warning: %post(katello-selinux-5.0.0-1.el8.noarch) scriptlet failed, exit status 1

    Error in POSTIN scriptlet in rpm package katello-selinux

Fixes: 85e372a3e34319331a5f9ec0fa3e46d10a3853d0